### PR TITLE
implement bucket tip count as an interrupt (issue #78)

### DIFF
--- a/software/ADPL_electron/ADPL_electron.ino
+++ b/software/ADPL_electron/ADPL_electron.ino
@@ -41,7 +41,6 @@ LevelSensor levelSensor(LEVEL);
 
 #include "Bucket.h"
 Bucket bucket(BUCKET);
-#define BUCKET_TIP_COUNT_DELAY 2500  // 2.5 s delay
 
 // initialize some time counters
 unsigned long currentTime = 0;
@@ -53,6 +52,8 @@ char temps_str [69];
 void setup() {
     Serial.begin(9600);
     Particle.variable("currentTime", currentTime);
+    // count bucket tips on one-shot rise
+    attachInterrupt(BUCKET, bucket_tipped, RISING);
 }
 
 void loop() {
@@ -109,19 +110,7 @@ void loop() {
             }
         }
     }
-
-    // count bucket tip
-    currentTime = millis();
-    if ((currentTime - bucket.tip_time) > BUCKET_TIP_COUNT_DELAY) {
-        bucket.read(); // read will also count if HIGH
-        if (bucket.tipped) {
-          bucket.publish();
-          bucket.tipped = false;
-        }
-    }
-
-} // end loop()
-
+}
 
 int read_temp(int temp_count) {
     switch (temp_count) {
@@ -148,4 +137,8 @@ int read_temp(int temp_count) {
     }
 
     return temp_count;
+}
+
+void bucket_tipped() {
+    bucket.tipped();
 }

--- a/software/ADPL_electron/Bucket.cpp
+++ b/software/ADPL_electron/Bucket.cpp
@@ -7,23 +7,14 @@
 
 Bucket::Bucket(int pin) {
     pinMode(pin, INPUT_PULLDOWN);
-    _pin = pin;
     unsigned long tip_time = 0;
     unsigned int tip_count = 0;
-    boolean tipped = false;
     Particle.variable("bucket", (int) tip_count);
 }
 
-void Bucket::read() {
-    // turn pump on and record time when that occurs
-    if (digitalRead(_pin) == 1) {
-        tip_time = millis();
-        tipped = true;
-        tip_count++;
-    }
-    else{
-      tipped = false;
-    }
+void Bucket::tipped() {
+    tip_time = millis();
+    tip_count++;
 }
 
 void Bucket::publish() {

--- a/software/ADPL_electron/Bucket.h
+++ b/software/ADPL_electron/Bucket.h
@@ -6,13 +6,10 @@
 class Bucket {
     public:
         Bucket(int pin);
-        void read();
+        void tipped();
         unsigned long tip_time;
         unsigned int tip_count;
-        boolean tipped;
         void publish();
-    private:
-        int _pin;
 };
 
 #endif


### PR DESCRIPTION
@aforbis-stokes I need you to test the bucket tip on ``ADPLDuke6191``.  I have implemented two things to hopefully fix the tip counting:

1. Cycle through the temp probe reading (one per loop now)
2. Implement bucket tip counting through an interrupt mechanism

The first change is working great; the second change appears to be working w/r to compiled code, but I'm not sure that it will actually work w/o directly testing the unit.

I have already flashed the lab device with this test code; let me know how it works.  If all looks good, then I'll merge it into the master branch.