### PR TITLE
Bucket Event DB schema, stream parsing, and API routes

### DIFF
--- a/software/cloud-dashboard/node-server/api/bucket-handlers.js
+++ b/software/cloud-dashboard/node-server/api/bucket-handlers.js
@@ -1,0 +1,27 @@
+/*
+ * bucket-handlers.js
+ * Module to hold handlers for API
+ * calls dealing with bucket events
+ *
+ * @author: Suyash Kumar <suyashkumar2003@gmail.com>
+ */
+var BucketEvent = require('../models/bucket-event');
+
+function sendDBEvents(err, records, res) {
+	if (err) {
+		res.json(err);
+	} else {
+		res.json(records);
+	}
+}
+
+module.exports = {
+	list: function(req, res) {
+		BucketEvent.find({}, (err, records) => sendDBEvents(err, records, res)); 
+	}, 
+	listLoc: function(req, res) {
+		BucketEvent.find({loc: req.params.loc}, (err, records) => sendDBEvents(err, records, res)); 
+
+	} 
+
+};

--- a/software/cloud-dashboard/node-server/api/temperature-handlers.js
+++ b/software/cloud-dashboard/node-server/api/temperature-handlers.js
@@ -1,6 +1,7 @@
 /*
- * logs.js
- * Module to hold all API functions dealing with logs
+ * temperature-handlers.js
+ * Module to hold all API functions dealing with temperature
+ * events
  * @author: Suyash Kumar <suyashkumar2003@gmail.com>
  */ 
 var TemperatureEvent = require('../models/temperature-event');

--- a/software/cloud-dashboard/node-server/config/routes.js
+++ b/software/cloud-dashboard/node-server/config/routes.js
@@ -5,16 +5,22 @@
  */
 
 var express = require('express');
-var logs = require('../api/logs.js');
-var message = require('../api/message.js'); 
-var sites = require('../api/sites.js');
-var ondemand = require('../api/ondemand.js');
+var temperatureHandlers = require('../api/temperature-handlers');
+var bucketHandlers = require('../api/bucket-handlers');
+var message = require('../api/message'); 
+var sites = require('../api/sites');
+var ondemand = require('../api/ondemand');
+
 module.exports = function(app) { 
-	app.get('/api/list', logs.list);
-	app.get('/api/list/:loc', logs.listLoc); 
-	app.get('/api/list-all/:loc',logs.listLocAll);
-	app.get('/api/list/:loc/:pin', logs.listPin);
+	app.get('/api/list', temperatureHandlers.list);
+	app.get('/api/list/:loc', temperatureHandlers.listLoc); 
+	app.get('/api/list-all/:loc',temperatureHandlers.listLocAll);
+	app.get('/api/list/:loc/:pin', temperatureHandlers.listPin);
 	app.get('/api/sites',sites.listSites);
 	app.get('/api/gasOn/:loc',ondemand.getValveStatus);
 	app.post('/api/message', message.onText);
+
+	// Bucket Endpoints
+	app.get('/api/bucket/list', bucketHandlers.list);
+	app.get('/api/bucket/list/:loc', bucketHandlers.listLoc);
 };

--- a/software/cloud-dashboard/node-server/handle-device.js
+++ b/software/cloud-dashboard/node-server/handle-device.js
@@ -6,80 +6,33 @@
  * @author: Suyash Kumar <suyashkumar2003@gmail.com>
  */
 var EventSource = require('eventsource'); // Pull in event source
-var TemperatureEvent = require('./models/temperature-event');
-var locMap = require('./config/device-map.js').locMap; 
-
-function addRecord(parsedData, io){
-	var newTemperatureEvent= {
-		coreid:		parsedData.coreid,
-		time:		new Date(parsedData.published_at),
-		loc:		locMap[parsedData.coreid], 
-		temps:		{
-			HXCI:	parsedData.HXCI,
-			HXCO:	parsedData.HXCO,
-			HTR:	parsedData.HTR,
-			HXHI:	parsedData.HXHI,
-			HXHO:	parsedData.HXHO
-		},
-		valveStatus: parsedData.V // Null if doesn't exist
-	}
-	
-	console.log(newTemperatureEvent);
-	var newRecord = new TemperatureEvent(newTemperatureEvent);  
-	newRecord.save(function(err, event){
-		if(err) console.log("error in saving to database"+err);
-	})
-	io.emit(newTemperatureEvent.probeid, newRecord);
-}
-
-/**
- * parseMessage
- * Responsible for parsing a Particle Publish 
- * message from the ADPL platform. A sample message
- * looks like:
- * {
- * 	"data": {
- * 		"data":"HXCI:18.9,HXCO:21.8,HTR:80.6,HXHI:22.7,HXHO:19.0",
- * 		""ttl":"60",
- * 		"published_at":"2016-12-02T06:18:25.026Z",
- * 		"coreid":"4b0031000d51353432393339"
- * 	}
- * }
- * This function returns a map of all the transducer fields to 
- * corresponding values along with published_at and coreid 
- * (e.g. {HXHO: 100, ... , coreid: "", published_at: ""})
- * @param {object} message
- * @return {object} a map of data fields to their values (including transducers) 
- */
-function parseMessage(message) {
-	deviceData = JSON.parse(message.data); 
-	const splitData = deviceData.data.split(",");
-	
-	// Parse Transducer data
-	const parsedData = splitData.reduce((result, current) => {
-		const currentSplit = current.split(":");
-		result[currentSplit[0]] = currentSplit[1];
-		return result;
-	}, {}); 
-	
-	// Add metadata
-	parsedData['published_at'] = deviceData['published_at'];
-	parsedData['coreid'] = deviceData['coreid'];
-
-	return parsedData;
-}
+var TempUtil = require('./handle-device/temp-util');
+var BucketUtil = require('./handle-device/bucket-util');
 
 function handleDevice(deviceUrl, io){
 	var es = new EventSource(deviceUrl); // Listen to the stream
+
+	// Add temperature event listener
     es.addEventListener("TEMPS", function (message) {
         console.log("New Message");
 		try {
-  			parsedData = parseMessage(message); 
-			addRecord(parsedData, io);
+  			const parsedData = TempUtil.parseMessage(message); 
+			TempUtil.addRecord(parsedData, io);
 		} catch (err) {
 			console.log("ERROR: Parsing Temps Message", message, err);	
 		}
     });
+
+	// Add bucket tip listener
+	es.addEventListener("BUCKET", function(message) {
+		try {
+			const parsedData = BucketUtil.parseMessage(message);
+			BucketUtil.addRecord(parsedData, io);
+		} catch (err) {
+			console.log("ERROR: Parsing BUCKET Message", message, err);
+		}
+
+	});
 
     es.onerror = function (err) {
         console.log("ERROR (Likely Event Source)");

--- a/software/cloud-dashboard/node-server/handle-device/bucket-util.js
+++ b/software/cloud-dashboard/node-server/handle-device/bucket-util.js
@@ -1,0 +1,53 @@
+/*
+ * handle-device/bucket-util.js
+ * A set of utility functions used to parse and save 
+ * bucket events published from ADPL systems.
+ * @author: Suyash Kumar <suyashkumar2003@gmail.com>
+ */
+
+var BucketEvent = require('../models/bucket-event'); 
+var locMap = require('../config/device-map.js').locMap; 
+
+/*
+ * addRecord
+ * Responsible for adding a bucket-event record
+ * to the database
+ * 
+ * @param {object} parsedData: Output from parseMessage below
+ * @param {object} io: socketio object
+ */
+function addRecord(parsedData, io) {
+	var newBucketEvent = {
+		coreid:		parsedData.coreid,
+		time:		new Date(parsedData.published_at),
+		loc:		locMap[parsedData.coreid],
+		data:		parsedData.data,
+	}
+
+	console.log(newBucketEvent);
+	var newRecord = new BucketEvent(newBucketEvent);
+	newRecord.save(function(err, event) {
+		if (err) console.log("error saving bucket event to database", err);
+	});
+	io.emit("BUCKET", newRecord);
+
+}
+
+/*
+ * parseMessage
+ * Parses bucket event published data from
+ * ADPL devices. 
+ *
+ * @param {object} Particle publish message
+ * @return {object} Parsed data
+ */
+function parseMessage(message) { 
+	deviceData = JSON.parse(message.data);
+	deviceData.data = parseInt(deviceData.data); 
+	return deviceData;
+}
+
+module.exports = {
+	parseMessage,
+	addRecord,
+}

--- a/software/cloud-dashboard/node-server/handle-device/temp-util.js
+++ b/software/cloud-dashboard/node-server/handle-device/temp-util.js
@@ -1,0 +1,81 @@
+/*
+ * handle-device/temp-util.js
+ * A set of utility functions used to parse and save 
+ * temperature events published from ADPL systems.
+ * @author: Suyash Kumar <suyashkumar2003@gmail.com>
+ */
+var TemperatureEvent = require('../models/temperature-event');
+var locMap = require('../config/device-map.js').locMap; 
+
+/*
+ * addRecord
+ * Responsible for adding a temperature-event record to
+ * the database.
+ *
+ * @param {object} parsedData: See output from parseMessage function below
+ * @param {oject} io: socketio object
+ */
+function addRecord(parsedData, io){
+	var newTemperatureEvent= {
+		coreid:		parsedData.coreid,
+		time:		new Date(parsedData.published_at),
+		loc:		locMap[parsedData.coreid], 
+		temps:		{
+			HXCI:	parsedData.HXCI,
+			HXCO:	parsedData.HXCO,
+			HTR:	parsedData.HTR,
+			HXHI:	parsedData.HXHI,
+			HXHO:	parsedData.HXHO
+		},
+		valveStatus: parsedData.V // Null if doesn't exist
+	}
+	
+	console.log(newTemperatureEvent);
+	var newRecord = new TemperatureEvent(newTemperatureEvent);  
+	newRecord.save(function(err, event){
+		if(err) console.log("error in saving to database"+err);
+	})
+	io.emit(newTemperatureEvent.probeid, newRecord);
+}
+
+/**
+ * parseMessage
+ * Responsible for parsing a Particle Temperature Publish 
+ * message from the ADPL platform. A sample message
+ * looks like:
+ * {
+ * 	"data": {
+ * 		"data":"HXCI:18.9,HXCO:21.8,HTR:80.6,HXHI:22.7,HXHO:19.0",
+ * 		""ttl":"60",
+ * 		"published_at":"2016-12-02T06:18:25.026Z",
+ * 		"coreid":"4b0031000d51353432393339"
+ * 	}
+ * }
+ * This function returns a map of all the transducer fields to 
+ * corresponding values along with published_at and coreid 
+ * (e.g. {HXHO: 100, ... , coreid: "", published_at: ""})
+ * @param {object} message
+ * @return {object} a map of data fields to their values (including transducers) 
+ */
+function parseMessage(message) {
+	deviceData = JSON.parse(message.data); 
+	const splitData = deviceData.data.split(",");
+	
+	// Parse Transducer data
+	const parsedData = splitData.reduce((result, current) => {
+		const currentSplit = current.split(":");
+		result[currentSplit[0]] = currentSplit[1];
+		return result;
+	}, {}); 
+	
+	// Add metadata
+	parsedData['published_at'] = deviceData['published_at'];
+	parsedData['coreid'] = deviceData['coreid'];
+
+	return parsedData;
+}
+
+module.exports = {
+	parseMessage,
+	addRecord
+}

--- a/software/cloud-dashboard/node-server/models/bucket-event.js
+++ b/software/cloud-dashboard/node-server/models/bucket-event.js
@@ -1,0 +1,16 @@
+/*
+ * bucket-event.js
+ * The schema to hold incoming bucket
+ * tip events from ADPL sites.
+ * @author: Suyash Kumar <suyashkumar2003@gmail.com>
+ */
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+var BucketEvent = new Schema({
+	coreid: {type: String, required: true, trim: true}, // Particle core id of sender
+	loc:	{type: String, required: true, trim: true}, // Location identifier
+	time:	{type: Date, required: true}, // Datetime of publish
+	data:	{type: Number, required: false}, // typically a tip count since reset 
+});
+
+module.exports = mongoose.model('BucketEvent', BucketEvent);

--- a/software/cloud-dashboard/node-server/server.js
+++ b/software/cloud-dashboard/node-server/server.js
@@ -38,9 +38,9 @@ require('./config/db')();
 // Set up app routes
 require('./config/routes')(app);
 
-// Set up device handler
-var deviceURL = "https://api.particle.io/v1/devices/events?access_token=7883544edea996822936af401fad4209c2ba5627"; 
-require('./handle-device.js')(deviceURL, io);
+// Set up ADPL devices handler
+var particleURL = "https://api.particle.io/v1/devices/events?access_token=7883544edea996822936af401fad4209c2ba5627"; 
+require('./handle-device.js')(particleURL, io);
 
 io.on('connection',function(socket){
 	console.log("hello");


### PR DESCRIPTION
This change makes the server-side changes to add the bucket tip event database schema, particle stream parsing, and corresponding API routes. This closes #123, closes #118, and closes #119. 

This change also includes several refactors of the existing code. Some more refactoring in the future may be warranted (see #124)