### PR TITLE
Initial Configurable Graph Options

### DIFF
--- a/software/cloud-dashboard/react-client/public/index.html
+++ b/software/cloud-dashboard/react-client/public/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+	<link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+	      rel="stylesheet">
     <!--
       Notice the use of %PUBLIC_URL% in the tag above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/software/cloud-dashboard/react-client/src/components/temp-view.js
+++ b/software/cloud-dashboard/react-client/src/components/temp-view.js
@@ -1,9 +1,14 @@
 import React, { Component, PropTypes } from 'react';
 import { Card, CardTitle } from 'react-toolbox/lib/card';
+import {Button, IconButton} from 'react-toolbox/lib/button'; 
 import ProgressBar from 'react-toolbox/lib/progress_bar';
 import TempPlot from './temp-view/temp-plot';
 
 class TempView extends Component {
+
+	state = {
+		tempPlotSidebarOpen: false
+	}
 
 	renderLoadingView = () => {
 		return (
@@ -12,6 +17,10 @@ class TempView extends Component {
 			</div>
 		)
 	} 
+
+	toggleTempPlotSidebar = () => {
+		return this.setState({tempPlotSidebarOpen: !this.state.tempPlotSidebarOpen});
+	}
 
 	render() {
 		return ( 
@@ -25,14 +34,21 @@ class TempView extends Component {
 					}
 				</Card>
 				<Card style={{minHeight: '400px', marginTop: '20px'}}> 
-					<CardTitle
-						title="Temperature Data"
-						subtitle="Last 3 Days"/>
+					<div style={{margin: '20px'}}>
+						<h3 style={{display: 'inline-block', float: 'left'}}> Temperature </h3>
+						<IconButton 
+							className="material-icons" 
+							style={{float: 'right'}} 
+							icon='menu'
+							onClick={this.toggleTempPlotSidebar}/>
+					</div>
 					{
 						this.props.temps.loading && 
 						this.renderLoadingView()
 					}
-					<TempPlot temps={this.props.temps}/>
+					<TempPlot 
+						temps={this.props.temps} 
+						sideBarOpen={this.state.tempPlotSidebarOpen}/>
 				</Card>
 			</div>
 		);

--- a/software/cloud-dashboard/react-client/src/components/temp-view/temp-plot.js
+++ b/software/cloud-dashboard/react-client/src/components/temp-view/temp-plot.js
@@ -35,7 +35,7 @@ class TempPlot extends Component {
 		const data = this.props.temps.data.map( currentItem => {
 			return { ...currentItem.temps, time: currentItem.time };
 		});
-		console.log(data.length);
+		
 		return ( 
 			<div style={{}}>
 			<Layout>

--- a/software/cloud-dashboard/react-client/src/components/temp-view/temp-plot.js
+++ b/software/cloud-dashboard/react-client/src/components/temp-view/temp-plot.js
@@ -1,9 +1,16 @@
 import React, { Component } from 'react';
+import {Button, IconButton} from 'react-toolbox/lib/button'; 
 import {LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend} from 'recharts' 
+import { Layout, NavDrawer, Panel, Sidebar } from 'react-toolbox'; 
+import Slider from 'react-toolbox/lib/slider'; 
 
 const LINE_COLORS = ['#e41a1c', '#377eb8', '#4daf4a', '#984ea3', '#ff7f00', '#ffff33']
 
 class TempPlot extends Component {
+	
+	state = {
+		downsampleFactor: 25
+	}
 
 	downsampleArray = (array, factor) => {
 		const downsampledArray = [];
@@ -18,33 +25,59 @@ class TempPlot extends Component {
 		return `${dateObj.getMonth().toString()}/${dateObj.getDate().toString()} ${dateObj.getHours()}:${dateObj.getMinutes()}`
 	}
 
+	handleSliderChange = (slider, value) => {
+		const newSliderState = {};
+		newSliderState[slider] = value;
+		this.setState(newSliderState);
+	}
+
 	renderPlot = () => {
 		const data = this.props.temps.data.map( currentItem => {
 			return { ...currentItem.temps, time: currentItem.time };
 		});
-
+		console.log(data.length);
 		return ( 
 			<div style={{}}>
-			<LineChart width={700} height={300} data={this.downsampleArray(data, 30).reverse()}>
-				<XAxis dataKey="time" interval={10} tickFormatter={this.formatDate} />
-				<YAxis />
-				{
-					Object.keys(data[0]).map((currentItem, index) => {
-						if (currentItem === 'time') return null;
-						return (
-							<Line 
-								type="monotone"
-								dataKey={currentItem} 
-								key={currentItem} 
-								stroke={LINE_COLORS[index]}/>
-						);
-					})
-				}
-				<Tooltip
-					labelFormatter={this.formatDate}/>
-				<Legend />
-				<CartesianGrid strokeDasharray="3 3" />
-			</LineChart> 
+			<Layout>
+					<Panel>
+							<LineChart width={700} height={300} data={this.downsampleArray(data, this.state.downsampleFactor).reverse()}>
+								<XAxis dataKey="time" interval={30} tickFormatter={this.formatDate} />
+								<YAxis />
+								{
+									Object.keys(data[0]).map((currentItem, index) => {
+										if (currentItem === 'time') return null;
+										return (
+											<Line 
+												type="monotone"
+												dataKey={currentItem} 
+												key={currentItem} 
+												stroke={LINE_COLORS[index]}/>
+										);
+									})
+								}
+								<Tooltip
+									labelFormatter={this.formatDate}/>
+								<Legend />
+								<CartesianGrid strokeDasharray="3 3" />
+							</LineChart> 
+					</Panel>
+					<Sidebar pinned={this.props.sideBarOpen} width={6}>
+						<div>
+							<h4> Plot Options </h4>
+							<p> Downsample Sampling Scale Factor </p>	
+							<Slider 
+								min={10} 
+								max={100} 
+								step={5}
+								pinned
+								snaps
+								editable 
+								value={this.state.downsampleFactor} 
+								onChange={this.handleSliderChange.bind(this, 'downsampleFactor')}/>
+
+						</div>
+					</Sidebar>
+			</Layout>
 			</div>
 		);
 	}


### PR DESCRIPTION
This change adds support for configurable graph options in a slide-out menu pane. Currently a simple downsampling factor is the only option, but others to come as per #121. This downsampling factor will likely be replaced by a period measurement to make it more readable and easy to understand. A photo and low FPS gif are below.

<img width="904" alt="screen shot 2016-12-27 at 10 53 20 pm" src="https://cloud.githubusercontent.com/assets/6299853/21513498/5238d14e-cc87-11e6-8e86-52167c6c00e2.png">

![test](https://cloud.githubusercontent.com/assets/6299853/21513499/56b871ca-cc87-11e6-920f-328cb8fa0f4e.gif)
