### PR TITLE
Bucket publish

### DIFF
--- a/software/ADPL_electron/ADPL_electron.ino
+++ b/software/ADPL_electron/ADPL_electron.ino
@@ -127,7 +127,12 @@ int publish_data(int last_publish_time) {
     bool publish_success;
     char data_str [69];
 
-    sprintf(data_str,"HXCI:%.1f,HXCO:%.1f,HTR:%.1f,HXHI:%.1f,HXHO:%.1f,V:%d,B:%d",
+    // allow for data str to be created that doesn't update bucket if count = 0
+    const char* fmt_string = "HXCI:%.1f,HXCO:%.1f,HTR:%.1f,HXHI:%.1f,HXHO:%.1f,V:%d,B:%d";
+    const char* fmt_string_no_bucket = "HXCI:%.1f,HXCO:%.1f,HTR:%.1f,HXHI:%.1f,HXHO:%.1f,V:%d";
+
+    // bucket.tip_count will be ignored if not needed by sprintf
+    sprintf(data_str, (bucket.tip_count > 0) ? fmt_string : fmt_string_no_bucket,
             tempHXCI.temp, tempHXCO.temp, tempHTR.temp, tempHXHI.temp, tempHXHO.temp,
             int(valve.gasOn), int(bucket.tip_count));
 
@@ -135,7 +140,8 @@ int publish_data(int last_publish_time) {
 
     if (publish_success) {
         last_publish_time = currentTime;
-        // reset the bucket tip count after every successful publish (webserver will accumulate count)
+        // reset the bucket tip count after every successful publish
+        // (webserver will accumulate count)
         bucket.tip_count = 0;
     }
 

--- a/software/ADPL_electron/Bucket.cpp
+++ b/software/ADPL_electron/Bucket.cpp
@@ -7,16 +7,10 @@
 
 Bucket::Bucket(int pin) {
     pinMode(pin, INPUT_PULLDOWN);
-    unsigned long tip_time = 0;
     unsigned int tip_count = 0;
     Particle.variable("bucket", (int) tip_count);
 }
 
 void Bucket::tipped() {
-    tip_time = millis();
     tip_count++;
-}
-
-void Bucket::publish() {
-    Particle.publish(String("BUCKET"), String(tip_count));
 }

--- a/software/ADPL_electron/Bucket.h
+++ b/software/ADPL_electron/Bucket.h
@@ -7,9 +7,7 @@ class Bucket {
     public:
         Bucket(int pin);
         void tipped();
-        unsigned long tip_time;
         unsigned int tip_count;
-        void publish();
 };
 
 #endif


### PR DESCRIPTION
Please see individual commit comments for what is going on with this... specifically ``TEMPS`` publish structure renamed ``DATA``, which now includes all temp, valve status and bucket tip data.  Bucket tip is reset after successful publish (based on return status of the command, not an actual handshake confirmation of received data).

I decided not the send ``last_publish_time`` in the publish data to save on bytes, but if that would help on the server end, then we can easily pass that off too.  It could get tricky in the event of a device reset and tracking absolute time, but it is possible.