### PR TITLE
update device ID map <-> name

### DIFF
--- a/software/cloud-dashboard/node-server/config/device-map.js
+++ b/software/cloud-dashboard/node-server/config/device-map.js
@@ -2,16 +2,20 @@
  * device-map.js
  * Holds mapping to/from coreid to internal loc identifier
  * @author: Suyash Kumar <suyashkumar2003@gmail.com>
+ *
+ * Updated (2017-02-03) by Mark Palmeri
  */
 module.exports={
 	locMap : {
-		"220036000b51343136333035": "ADPLKenyaC6304",
-        "3e001d000e51353432393339": "ADPLKenyaN3763",
+		"220036000b51343136333035": "ADPLKenyaC2212",
+		"4b0031000d51353432393339": "ADPLKenyaC6304",
+        "3e001d000e51353432393339": "ADPLKenyaN6833",
         "400057000a51343334363138": "ADPLDuke0785",
+        "20002a001951353338363036": "ADPLDuke6191",
 		"310057000951343334363138": "ADPLPhilippinesSagay3904",
 		"170044000c51343334363138": "ADPLPhilippinesSubayon1817",
         "430055000951343334363138": "ADPLIndia3847",
-        "2d0042000951343334363138": "ADPLIndia2723"
+        "2d0042000951343334363138": "ADPLindia2723"
 	}, // Maps coreids to a location identifier
 	locMapRev : function(){ 
 		revMap = {};


### PR DESCRIPTION
Several devices had names and IDs that did not match what the particle cloud had registered; these have been updated.

@aforbis-stokes please confirm that remapping the names to correctly reflect the device IDs won't break anything on your end.

@suyashkumar same comment as above, but w/r to the database; do you store by name or ID?