### PR TITLE
ADD system firmware as Particle variable

### DIFF
--- a/software/ADPL_electron/ADPL_electron.ino
+++ b/software/ADPL_electron/ADPL_electron.ino
@@ -12,6 +12,8 @@
 SYSTEM_THREAD(ENABLED);  // parallel user and system threads
                          // to allow function w/o cell connectivity
 
+unsigned long SYS_VERSION;
+
 #define PUBLISH_DELAY 150000  // 2.5 min b/w variable publish
 
 #include "pin_mapping.h"
@@ -50,6 +52,10 @@ void setup() {
     Particle.variable("currentTime", currentTime);
     // count bucket tips on one-shot rise
     attachInterrupt(BUCKET, bucket_tipped, RISING);
+
+    // collect the system firmware version to fetch OTA
+    SYS_VERSION = System.versionNumber();
+    Particle.variable("SYS_VERSION", SYS_VERSION);
 }
 
 void loop() {


### PR DESCRIPTION
Exposed variable: SYS_VERSION (int16 representation of hex)
  hex version is 0xAABBCCDD, where:
    AA - major release #
    BB - minor release #
    CC - patch #
    DD - 00

Closes #74 