### PR TITLE
Removed level sensor, bucket same for all

### DIFF
--- a/software/ADPL_electron/pin_mapping.h
+++ b/software/ADPL_electron/pin_mapping.h
@@ -7,6 +7,4 @@
 #define VALVE 4
 #define IGNITOR 2
 #define PUMP D0
-//#define LEVEL B5
-//#define BUCKET C0 // Duke
-#define BUCKET C4 // Kenya
+#define BUCKET C4 // 


### PR DESCRIPTION
The location for the tipping bucket pin is the same in all locations now.