### PR TITLE
move interrupt methods to loop

### DIFF
--- a/software/ADPL_electron/ADPL_electron.ino
+++ b/software/ADPL_electron/ADPL_electron.ino
@@ -113,6 +113,13 @@ void loop() {
         }
     }
 
+    if(pinchValve.down) {
+        pinchValve.shiftDown();
+    }
+
+    if(pinchValve.up) (
+        pinchValve.shiftUp();
+    }
 }
 
 int read_temp(int temp_count) {
@@ -147,9 +154,9 @@ void bucket_tipped() {
 }
 
 void up_pushed() {
-    pinchValve.shiftUp();
+    pinchValve.up = true;
 }
 
 void down_pushed(){
-    pinchValve.shiftDown();
+    pinchValve.down = true;
 }


### PR DESCRIPTION
* interrupt calls were freezing the Particle, thought to be due to
"long" runtime of interrupt methods.  changes approach to interrupt
toggles a Booblean, and then methods are executed in loop()

* Daniel needs to test before any master-level merges