### PR TITLE
Update Docker config to build frontend static assets on start

### DIFF
--- a/software/cloud-dashboard/Dockerfile
+++ b/software/cloud-dashboard/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:latest
+
+# Initialize Workspace
+WORKDIR /app
+RUN mkdir /app/node-server
+RUN mkdir /app/react-client
+COPY ./node-server /app/node-server
+COPY ./react-client /app/react-client
+
+# Install and build frontend dependencies. This will build frontend static assets
+# and place them in the node-server/public directory for serving.
+RUN cd /app/react-client && npm install
+RUN cd /app/react-client && npm run build
+
+# Install server dependencies
+RUN cd /app/node-server && npm install
+
+CMD node server.js

--- a/software/cloud-dashboard/Dockerfile
+++ b/software/cloud-dashboard/Dockerfile
@@ -15,4 +15,4 @@ RUN cd /app/react-client && npm run build
 # Install server dependencies
 RUN cd /app/node-server && npm install
 
-CMD node server.js
+CMD node ./node-server/server.js

--- a/software/cloud-dashboard/docker-compose.yml
+++ b/software/cloud-dashboard/docker-compose.yml
@@ -1,14 +1,13 @@
 version: '2'
 services: 
   server:
-    build: 
-      context: node-server
+    build: .
     environment: 
       - MONGO_URI="mongodb://db/adpl"
     ports:
         - 80:4000
     restart: always
-    command: ["./wait-for-it.sh", "db:27017", "--", "node", "server.js"]
+    command: ["./node-server/wait-for-it.sh", "db:27017", "--", "node", "./node-server/server.js"]
   db:
     image: mongo:latest
     ports:

--- a/software/cloud-dashboard/node-server/Dockerfile
+++ b/software/cloud-dashboard/node-server/Dockerfile
@@ -1,4 +1,4 @@
-from node:latest
+FROM node:latest
 WORKDIR /app
 COPY . /app
 RUN npm install


### PR DESCRIPTION
This change revises the cloud-dashboard `docker-compose` configuration to build the latest frontend static assets every time the server container is built. The frontend static assets are built and placed in `node-server/public` directory so that the server can serve the latest frontend static assets in production. 

TODO: the `node-server/public` directory was previously committed to this repository and represented the latest build of the frontend being served in production. This should be deleted, as that will now be overwritten with the latest frontend code if the stack is started using this docker-compose configuration. See #304. 